### PR TITLE
Fix: explicitly require map.el

### DIFF
--- a/hammy.el
+++ b/hammy.el
@@ -47,7 +47,7 @@
 
 (require 'cl-lib)
 (require 'ring)
-
+(require 'map)
 (require 'ts)
 
 ;;;; Structs


### PR DESCRIPTION
Otherwise the pcase-defmacro for map elements is not guaranteed to be defined.
Fixes #2